### PR TITLE
Architecture followup and tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -708,7 +708,7 @@ mod tests {
     }
 
     #[test]
-    fn test_small_list() {
+    fn test_finds_small_list() {
         fn sum_greater_1000(tc: &mut TestCase) -> Status {
             let d = data::vectors(data::integers(0, 10000), 0, 1000);
             match d.produce(tc) {
@@ -723,5 +723,27 @@ mod tests {
 
         let d = data::vectors(data::integers(0, 10000), 0, 1000);
         assert_eq!(ts.result_as(d).unwrap(), vec![1001]);
+    }
+
+    #[test]
+    fn test_finds_small_list_even_with_bad_lists() {
+        use std::convert::TryInto;
+
+        struct BadList;
+        impl Possibility<Vec<i64>> for BadList {
+            fn produce(&self, tc: &mut TestCase) -> Result<Vec<i64>, Error> {
+                let n = tc.choice(10)?;
+                let result = (0..n).map(|_| {tc.choice(10000)}).collect::<Result<Vec<u64>, Error>>()?;
+                Ok(result.iter().map(|i| *i as i64).collect())
+            }
+        }
+
+        fn sum_greater_1000(tc: &mut TestCase) -> Status {
+            let ls = BadList.produce(tc);
+            match BadList.produce(tc) {
+                Ok(ls) => if ls.iter().sum::<i64>() > 1000 { Status::Interesting } else { Status::Valid },
+                Err(_) => Status::Invalid
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,6 @@ pub struct TestCase {
     random: ThreadRng,
     max_size: usize,
     choices: Vec<u64>,
-    status: Option<bool>,
-    depth: u64,
 }
 
 use crate::data::Possibility;
@@ -26,8 +24,6 @@ impl TestCase {
             random,
             max_size,
             choices: vec![],
-            status: None,
-            depth: 0,
         }
     }
 
@@ -37,8 +33,6 @@ impl TestCase {
             prefix,
             random: thread_rng(),
             choices: vec![],
-            status: None,
-            depth: 0,
         }
     }
 
@@ -719,13 +713,6 @@ mod tests {
         assert_eq!(ts.shrink_redistribute(&[500, 500, 500], 2), Some(vec![0, 500, 1000]));
     }
 
-    #[test]
-    fn produce_with_deterministic_test_case() {
-        // TODO: add more tests here
-        let d = data::vectors(data::integers(0, 10000), 0, 1000);
-        let mut tc = TestCase::for_choices(vec![1, 1001, 0]);
-        assert_eq!(d.produce(&mut tc).unwrap(), vec![1001]);
-    }
 
     #[test]
     fn finds_small_list() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,19 @@ mod data {
         }
     }
 
+    struct Pairs<U, T: Possibility<U>, V, S: Possibility<V>> {
+        first: T,
+        second: S,
+        phantom_u: PhantomData<U>,
+        phantom_v: PhantomData<V>,
+    }
+
+    impl<U, T: Possibility<U>, V, S: Possibility<V>> Possibility<(U, V)> for Pairs<U, T, V, S> {
+        fn produce(&self, tc: &mut TestCase) -> Result<(U, V), Error> {
+            Ok((self.first.produce(tc)?, self.second.produce(tc)?))
+        }
+    }
+
     pub struct Just<T: Clone> {
         value: T,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,15 +380,6 @@ impl TestState {
         }
     }
 
-    fn result_as<T>(&self, p: impl Possibility<T>) -> Option<T> {
-        if let Some(choices) = &self.result {
-            // TODO: proper error handling
-            Some(p.produce(&mut TestCase::for_choices(choices.to_vec())).unwrap())
-        } else {
-            None
-        }
-    }
-
     fn run(&mut self) {
         self.generate();
         self.shrink();
@@ -747,8 +738,7 @@ mod tests {
         let mut ts = TestState::new(thread_rng(), Box::new(sum_greater_1000), 10000);
         ts.run();
 
-        let d = data::vectors(data::integers(0, 10000), 0, 1000);
-        assert_eq!(ts.result_as(d).unwrap(), vec![1001]);
+        assert_eq!(ts.result, Some(vec![1, 1001, 0]));
     }
 
 
@@ -759,13 +749,12 @@ mod tests {
             Ok(ls.iter().sum::<i64>() > 1000)
         }
         
-        let d = data::vectors(data::integers(0, 10000), 0, 1000);
         let mut ts = TestState::new(thread_rng(), Box::new(sum_greater_1000), 10000);
         ts.result = Some(vec![1, 0, 1, 1001, 0]);
         // This buggy case came about due to the fact that rust compares vecs element by element.
         // assert!(vec![1, 1001, 0] < vec![1, 0, 1, 1001, 0]);
         assert_eq!(ts.shrink_remove(&[1, 0, 1, 1001, 0], 2), Some(vec![1, 1001, 0]));
-        assert_eq!(ts.result_as(d).unwrap(), vec![1001]);
+        assert_eq!(ts.result, Some(vec![1, 1001, 0]));
     }
 
 
@@ -787,7 +776,7 @@ mod tests {
 
         let mut ts = TestState::new(thread_rng(), Box::new(sum_greater_1000), 10000);
         ts.run();
-        assert_eq!(ts.result_as(BadList), Some(vec![1001]));
+        assert_eq!(ts.result, Some(vec![1, 1001]));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,7 +627,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_test_function_interesting() {
+    fn test_function_interesting() {
         let mut ts = TestState::new(thread_rng(), Box::new(|_| Status::Interesting), 10000);
 
         let mut tc = TestCase::new((&[]).to_vec(), thread_rng(), 10000);
@@ -646,7 +646,7 @@ mod tests {
     }
 
     #[test]
-    fn test_test_function_valid() {
+    fn test_function_valid() {
         let mut ts = TestState::new(thread_rng(), Box::new(|_| Status::Valid), 10000);
 
         let mut tc = TestCase::new((&[]).to_vec(), thread_rng(), 10000);
@@ -659,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn test_test_function_invalid() {
+    fn test_function_invalid() {
         let mut ts = TestState::new(thread_rng(), Box::new(|_| Status::Invalid), 10000);
 
         let mut tc = TestCase::new((&[]).to_vec(), thread_rng(), 10000);
@@ -668,7 +668,7 @@ mod tests {
     }
     
     #[test]
-    fn test_shrink_remove() {
+    fn shrink_remove() {
         let mut ts = TestState::new(thread_rng(), Box::new(|_| Status::Interesting), 10000);
         ts.result = Some(vec![1, 2, 3]);
 
@@ -689,7 +689,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shrink_redistribute() {
+    fn shrink_redistribute() {
         let mut ts = TestState::new(thread_rng(), Box::new(|_| Status::Interesting), 10000);
 
         ts.result = Some(vec![500, 500, 500, 500]);
@@ -700,7 +700,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deterministic() {
+    fn produce_with_deterministic_test_case() {
         // TODO: add more tests here
         let d = data::vectors(data::integers(0, 10000), 0, 1000);
         let mut tc = TestCase::for_choices(vec![1, 1001, 0]);
@@ -708,7 +708,7 @@ mod tests {
     }
 
     #[test]
-    fn test_finds_small_list() {
+    fn finds_small_list() {
         fn sum_greater_1000(tc: &mut TestCase) -> Status {
             let d = data::vectors(data::integers(0, 10000), 0, 1000);
             match d.produce(tc) {
@@ -726,7 +726,7 @@ mod tests {
     }
 
     #[test]
-    fn test_finds_small_list_even_with_bad_lists() {
+    fn finds_small_list_even_with_bad_lists() {
         use std::convert::TryInto;
 
         struct BadList;

--- a/src/main.rs
+++ b/src/main.rs
@@ -727,8 +727,6 @@ mod tests {
 
     #[test]
     fn finds_small_list_even_with_bad_lists() {
-        use std::convert::TryInto;
-
         struct BadList;
         impl Possibility<Vec<i64>> for BadList {
             fn produce(&self, tc: &mut TestCase) -> Result<Vec<i64>, Error> {
@@ -745,5 +743,24 @@ mod tests {
                 Err(_) => Status::Invalid
             }
         }
+
+        let mut ts = TestState::new(thread_rng(), Box::new(sum_greater_1000), 10000);
+        ts.run();
+        assert_eq!(ts.result_as(BadList), Some(vec![1001]));
+    }
+
+    #[test]
+    fn reduces_additive_pairs() {
+        fn sum_greater_1000(tc: &mut TestCase) -> Status {
+            if let (Ok(n), Ok(m)) = (tc.choice(1000), tc.choice(1000)) {
+                if m + n > 1000 { Status::Interesting } else { Status::Valid }
+            } else {
+                Status::Invalid
+            }
+        }
+
+        let mut ts = TestState::new(thread_rng(), Box::new(sum_greater_1000), 10000);
+        ts.run();
+        assert_eq!(ts.result, Some(vec![0, 1001]));
     }
 }


### PR DESCRIPTION
In this PR, I've done three things:
* Write tests based on https://github.com/DRMacIver/minithesis/blob/master/test_minithesis.py They aren't all translated, but it's a good start. This did add a ton of Todos.
* Fix bugs found through those tests. There were several, such as Rust saying that `vec![1, 1000, 1, 2]` is less than `vec![1000, 1]`, which differs from our definition.
* Adjusted the API so that `Status` no longer exists. Rather, `Invalid` test cases are signaled via an `Error` variant, allowing the user to simply type `data::integers(0, 10).produce(test_case)?` and let any error propagate as invalid test case.